### PR TITLE
Fix Unit Tests (add isReminderEnabled field)

### DIFF
--- a/app/src/test/java/edu/card/clarity/domain/creditCard/CashBackCreditCardTest.kt
+++ b/app/src/test/java/edu/card/clarity/domain/creditCard/CashBackCreditCardTest.kt
@@ -45,7 +45,8 @@ class CashBackCreditCardTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true,
         )
 
         val purchaseRewards = listOf(

--- a/app/src/test/java/edu/card/clarity/domain/creditCard/PointBackCreditCardTest.kt
+++ b/app/src/test/java/edu/card/clarity/domain/creditCard/PointBackCreditCardTest.kt
@@ -46,7 +46,8 @@ class PointBackCreditCardTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true,
         )
 
         val purchaseRewards = listOf(
@@ -94,7 +95,8 @@ class PointBackCreditCardTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true,
         )
 
         val purchaseRewards = listOf(

--- a/app/src/test/java/edu/card/clarity/repositories/PointSystemRepositoryTest.kt
+++ b/app/src/test/java/edu/card/clarity/repositories/PointSystemRepositoryTest.kt
@@ -159,7 +159,8 @@ class PointSystemRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val creditCardId2 = UUID.randomUUID()
         val creditCardInfoEntity2 = CreditCardInfoEntity(
@@ -168,7 +169,8 @@ class PointSystemRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val pointSystemEntity = PointSystemEntity(
             id = pointSystemId,

--- a/app/src/test/java/edu/card/clarity/repositories/creditCard/CashBackCreditCardRepositoryTest.kt
+++ b/app/src/test/java/edu/card/clarity/repositories/creditCard/CashBackCreditCardRepositoryTest.kt
@@ -126,7 +126,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true
         )
 
         val creditCardInfoEntity = CreditCardInfoEntity(
@@ -135,7 +136,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getRewardTypeById(creditCardInfo.id!!)).thenReturn(RewardType.CashBack)
@@ -155,7 +157,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity = PurchaseRewardEntity(
             creditCardId = creditCardId,
@@ -187,7 +190,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getInfoById(creditCardId)).thenReturn(creditCardInfoEntity)
@@ -208,7 +212,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity1 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity1.id,
@@ -223,7 +228,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity2 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity2.id,
@@ -262,7 +268,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         val creditCardInfoEntity2 = CreditCardInfoEntity(
@@ -271,7 +278,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getAllInfoOf(RewardType.CashBack)).thenReturn(
@@ -295,7 +303,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity1 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity1.id,
@@ -310,7 +319,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity2 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity2.id,
@@ -351,7 +361,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val creditCardInfoEntity2 = CreditCardInfoEntity(
             id = UUID.randomUUID(),
@@ -359,7 +370,8 @@ class CashBackCreditCardRepositoryTest {
             rewardType = RewardType.CashBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.observeAllInfoOf(RewardType.CashBack)).thenReturn(

--- a/app/src/test/java/edu/card/clarity/repositories/creditCard/PointBackCreditCardRepositoryTest.kt
+++ b/app/src/test/java/edu/card/clarity/repositories/creditCard/PointBackCreditCardRepositoryTest.kt
@@ -133,7 +133,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true
         )
 
         val creditCardInfoEntity = CreditCardInfoEntity(
@@ -142,7 +143,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = statementDate,
-            paymentDueDate = paymentDueDate
+            paymentDueDate = paymentDueDate,
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getRewardTypeById(creditCardInfo.id!!)).thenReturn(RewardType.PointBack)
@@ -163,7 +165,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity = PurchaseRewardEntity(
             creditCardId = creditCardId,
@@ -210,7 +213,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getInfoById(creditCardId)).thenReturn(creditCardInfoEntity)
@@ -230,7 +234,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity1 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity1.id,
@@ -250,7 +255,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity2 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity2.id,
@@ -313,7 +319,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         val creditCardInfoEntity2 = CreditCardInfoEntity(
@@ -322,7 +329,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.getAllInfoOf(RewardType.PointBack)).thenReturn(
@@ -346,7 +354,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity1 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity1.id,
@@ -366,7 +375,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val purchaseRewardEntity2 = PurchaseRewardEntity(
             creditCardId = creditCardInfoEntity2.id,
@@ -430,7 +440,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
         val creditCardInfoEntity2 = CreditCardInfoEntity(
             id = UUID.randomUUID(),
@@ -438,7 +449,8 @@ class PointBackCreditCardRepositoryTest {
             rewardType = RewardType.PointBack,
             cardNetworkType = CardNetworkType.Visa,
             statementDate = Calendar.getInstance(),
-            paymentDueDate = Calendar.getInstance()
+            paymentDueDate = Calendar.getInstance(),
+            isReminderEnabled = true
         )
 
         `when`(creditCardDao.observeAllInfoOf(RewardType.PointBack)).thenReturn(


### PR DESCRIPTION
[This PR](https://github.com/LideLinusZhang/cs446-project/pull/43) created a migration to add the isReminderEnabled field to the creditCardInfo table. 
This PR adds that field to the unit tests to fix the build.