### PR TITLE
Add Card Screen - UI Changes

### DIFF
--- a/app/src/main/java/edu/card/clarity/presentation/addCardScreen/AddCardScreen.kt
+++ b/app/src/main/java/edu/card/clarity/presentation/addCardScreen/AddCardScreen.kt
@@ -1,12 +1,9 @@
 package edu.card.clarity.presentation.addCardScreen
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -16,14 +13,23 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import edu.card.clarity.presentation.common.DropdownMenu
 
 @Composable
 fun AddCardScreen(navController: NavController) {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var selectedTemplateIndex by remember { mutableIntStateOf(-1) }
+    val dummyTemplates = listOf(
+        Template("Template 1", "Visa", "Cash Back"),
+        Template("Template 2", "MasterCard", "Points Back"),
+        Template("Template 3", "Amex", "Points Back")
+    )
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
-            .padding(horizontal = 32.dp, vertical = 40.dp),
+            .padding(horizontal = 16.dp, vertical = 24.dp),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.Top
     ) {
@@ -41,6 +47,48 @@ fun AddCardScreen(navController: NavController) {
             modifier = Modifier.padding(bottom = 24.dp)
         )
 
+        TabRow(
+            selectedTabIndex = selectedTabIndex,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Tab(
+                selected = selectedTabIndex == 0,
+                onClick = { selectedTabIndex = 0 },
+                text = { Text("Use a Template") }
+            )
+            Tab(
+                selected = selectedTabIndex == 1,
+                onClick = { selectedTabIndex = 1 },
+                text = { Text("Add Custom Card") }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (selectedTabIndex == 0) {
+            Column {
+                DropdownMenu(
+                    label = "Credit Card",
+                    options = dummyTemplates.map { it.name },
+                    selectedOption = if (selectedTemplateIndex != -1) dummyTemplates[selectedTemplateIndex].name else "Select a template",
+                    onOptionSelected = { selectedTemplateIndex = it }
+                )
+                if (selectedTemplateIndex != -1) {
+                    val template = dummyTemplates[selectedTemplateIndex]
+                    UseTemplateCardInformationForm(template)
+                }
+            }
+        } else {
+            AddCustomCardContent(navController)
+        }
+    }
+}
+
+@Composable
+fun AddCustomCardContent(navController: NavController) {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
         CardInformationForm(navController)
     }
 }
@@ -51,3 +99,9 @@ fun AddCardScreenPreview() {
     val navController = rememberNavController()
     AddCardScreen(navController)
 }
+
+data class Template(
+    val name: String,
+    val cardNetwork: String,
+    val rewardType: String
+)

--- a/app/src/main/java/edu/card/clarity/presentation/addCardScreen/UseTemplateCardInformationForm.kt
+++ b/app/src/main/java/edu/card/clarity/presentation/addCardScreen/UseTemplateCardInformationForm.kt
@@ -1,0 +1,120 @@
+package edu.card.clarity.presentation.addCardScreen
+
+import android.app.DatePickerDialog
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import edu.card.clarity.presentation.common.DatePickerField
+import java.util.Calendar
+
+@Composable
+fun UseTemplateCardInformationForm(template: Template) {
+    val context = LocalContext.current
+    val calendar = Calendar.getInstance()
+
+    var statementDate by remember { mutableStateOf("") }
+    var paymentDueDate by remember { mutableStateOf("") }
+    var isReminderEnabled by remember { mutableStateOf(true) }
+
+    val statementDatePickerDialog = remember {
+        DatePickerDialog(
+            context,
+            { _, year, month, dayOfMonth ->
+                statementDate = "$dayOfMonth/${month + 1}/$year"
+            },
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH),
+            calendar.get(Calendar.DAY_OF_MONTH)
+        )
+    }
+
+    val paymentDatePickerDialog = remember {
+        DatePickerDialog(
+            context,
+            { _, year, month, dayOfMonth ->
+                paymentDueDate = "$dayOfMonth/${month + 1}/$year"
+            },
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH),
+            calendar.get(Calendar.DAY_OF_MONTH)
+        )
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Non-Editable Card information based on the template chosen
+        Text(
+            text = "Card Name: ${template.name}",
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
+        Text(
+            text = "Card Network: ${template.cardNetwork}",
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
+        Text(
+            text = "Reward Type: ${template.rewardType}",
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
+
+        DatePickerField(
+            date = statementDate,
+            label = "Most Recent Statement Date",
+            onClick = statementDatePickerDialog::show
+        )
+        DatePickerField(
+            date = paymentDueDate,
+            label = "Most Recent Payment Due Date",
+            onClick = paymentDatePickerDialog::show
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "Payment Reminder:",
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            Switch(
+                checked = isReminderEnabled,
+                onCheckedChange = { isReminderEnabled = it }
+            )
+        }
+
+        Button(
+            onClick = {
+                // ADD CARD ACTION
+            },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.White,
+                contentColor = Color.Black
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(1.dp, Color.Black, RoundedCornerShape(8.dp))
+        ) {
+            Text(text = "Add Card to My Cards")
+        }
+    }
+}


### PR DESCRIPTION
<img width="846" alt="image" src="https://github.com/user-attachments/assets/61874793-e2c8-4a91-ba15-bd5a11813666">

## Changes:

**Template Selection in AddCardScreen:**
- Toggle between 'custom card' and 'use template'.
- Added a dropdown menu to select a card template.
- Updated logic to display template-specific card information upon selection.
- Displayed non-editable fields for "Card Name," "Card Network," and "Reward Type" based on the selected template.